### PR TITLE
Added support for IPv6

### DIFF
--- a/src/unyte_reuseport_kern.c
+++ b/src/unyte_reuseport_kern.c
@@ -2,6 +2,10 @@
 #include "vmlinux.h"
 // clang-format on
 #include <bpf/bpf_helpers.h>
+#include <bpf/bpf_endian.h>
+
+// https://elixir.bootlin.com/linux/latest/source/include/uapi/linux/if_ether.h#L52
+#define ETH_P_IP	0x0800
 
 #ifndef MAX_BALANCER_COUNT
 // Keep in sync with _user.c
@@ -73,7 +77,7 @@ struct {
 
 static inline __u32 rol32(__u32 word, unsigned int shift) { return (word << (shift & 31)) | (word >> ((-shift) & 31)); }
 
-static inline u32 hash(u32 ip) {
+static inline u32 hash(u32 ip_p1, u32 ip_p2, u32 ip_p3, u32 ip_p4) {
   u32 a, b, c, initval, *n;
 
   // Initialize nonce if not done already
@@ -95,7 +99,7 @@ static inline u32 hash(u32 ip) {
   initval = *n;
 
   initval += JHASH_INITVAL + (3 << 2);
-  a = ip + initval;
+  a = ip_p1 + ip_p2 + ip_p3 + ip_p4 + initval;
   b = initval;
   c = initval;
 
@@ -104,14 +108,23 @@ static inline u32 hash(u32 ip) {
 }
 
 // CORE LOGIC
+// sk_reuseport_md: https://elixir.bootlin.com/linux/latest/source/include/uapi/linux/bpf.h#L5655
+// https://git.yoctoproject.org/linux-yocto-contrib/plain/tools/testing/selftests/bpf/progs/test_select_reuseport_kern.c
 
 SEC("sk_reuseport/selector")
 enum sk_action _selector(struct sk_reuseport_md *reuse) {
   enum sk_action action;
   struct iphdr ip;
-  u32 key;
+  struct ipv6hdr ipv6;
 
+  u32 key;
+  // https://en.wikipedia.org/wiki/EtherType
+  int is_ipv4 = reuse->eth_protocol == bpf_htons(ETH_P_IP);
   void *targets;
+
+  // initialization -- resolve invalid indirect read from the stack (https://stackoverflow.com/questions/71529801/ebpf-bpf-map-update-returns-the-invalid-indirect-read-from-stack-error)
+  __builtin_memset(&ipv6, 0, sizeof(struct ipv6hdr));
+  __builtin_memset(&ip, 0, sizeof(struct iphdr));
 
   switch (reuse->ip_protocol) {
     case IPPROTO_TCP:
@@ -127,7 +140,11 @@ enum sk_action _selector(struct sk_reuseport_md *reuse) {
       return SK_DROP;
   }
 
-  bpf_skb_load_bytes_relative(reuse, 0, &ip, sizeof(struct iphdr), (u32)BPF_HDR_START_NET);
+  if(is_ipv4){
+    bpf_skb_load_bytes_relative(reuse, 0, &ip, sizeof(struct iphdr), (u32)BPF_HDR_START_NET);
+  } else {
+    bpf_skb_load_bytes_relative(reuse, 0, &ipv6, sizeof(struct ipv6hdr), (u32)BPF_HDR_START_NET);
+  }
 
   const u32 *balancer_count = bpf_map_lookup_elem(&size, &zero);
   if (!balancer_count || *balancer_count == 0) {  // uninitialized by userspace
@@ -140,10 +157,23 @@ enum sk_action _selector(struct sk_reuseport_md *reuse) {
 #endif
 
   // hash on the IP only
-  key = hash(__builtin_bswap32(ip.saddr)) % *balancer_count;
+  if(is_ipv4){
+    key = hash(__builtin_bswap32(ip.saddr),0,0,0) % *balancer_count;
+  } else {
+    key = hash(
+      __builtin_bswap32(ipv6.saddr.in6_u.u6_addr32[0]),
+      __builtin_bswap32(ipv6.saddr.in6_u.u6_addr32[1]),
+      __builtin_bswap32(ipv6.saddr.in6_u.u6_addr32[2]),
+      __builtin_bswap32(ipv6.saddr.in6_u.u6_addr32[3])
+    ) % *balancer_count;
+  }
 
 #ifdef _LOG_DEBUG
-  bpf_printk(LOC "src: %x, dest: %x, key: %d\n", __builtin_bswap32(ip.saddr), __builtin_bswap32(ip.daddr), key);
+  if(is_ipv4){
+    bpf_printk(LOC "src4: %x, dest4: %x, key: %d\n", __builtin_bswap32(ip.saddr), __builtin_bswap32(ip.daddr), key);
+  }else{
+    bpf_printk(LOC "[Last 32b] src6: %x, dest6: %x, key: %d\n", __builtin_bswap32(ipv6.saddr.in6_u.u6_addr32[3]), __builtin_bswap32(ipv6.daddr.in6_u.u6_addr32[3]), key);
+  }
 #endif
 
   // side-effect sets dst socket if found


### PR DESCRIPTION
This PR adds IPv6 support. In particular, the hash value is now computed on all bytes of an IPv6 address, and not only on the first 4.